### PR TITLE
fix typo in data - level 2

### DIFF
--- a/level2/data.json
+++ b/level2/data.json
@@ -2,7 +2,7 @@
   "workers": [
     { "id": 1, "first_name": "Julie", "status": "medic" },
     { "id": 2, "first_name": "Marc", "status": "medic" },
-    { "id": 3, "first_name": "Antoine", "status": "interne" },
+    { "id": 3, "first_name": "Antoine", "status": "intern" },
     { "id": 4, "first_name": "Emilie", "status": "medic" }
   ],
   "shifts": [


### PR DESCRIPTION
Remove `e` from `interne`.

[README.md](https://github.com/honestica/backend-jobs/blob/master/level2/README.md):

> A worker is either a `medic` or an **`intern`** and their shifts are paid according their status.

[data.json](https://github.com/honestica/backend-jobs/blob/master/level2/data.json): 

> `{ "id": 3, "first_name": "Antoine", "status": "interne" }`